### PR TITLE
改内部链接为路径 & 双斜杠注释后加空格更美观

### DIFF
--- a/Navigation.md
+++ b/Navigation.md
@@ -27,20 +27,20 @@
     - [.NET6.0][.NET6.0]
 
 
-[FAQs]: https://github.com/lyc-Lacewing/tMLAllInOne/blob/master/IssuesAndSolutions/FAQs.md
-[UsersManual]: https://github.com/lyc-Lacewing/tMLAllInOne/blob/master/README.md#%E7%94%A8%E6%88%B7%E6%89%8B%E5%86%8C
+[FAQs]: ./issue-and-solutions/FAQs.md
+[UsersManual]: README.md#%E7%94%A8%E6%88%B7%E6%89%8B%E5%86%8C
 
-[GetTerraria]: https://github.com/lyc-Lacewing/tMLAllInOne/blob/master/IssuesAndSolutions/tML/GetTerraria.md
-[WhatIsTML]: https://github.com/lyc-Lacewing/tMLAllInOne/blob/master/IssuesAndSolutions/tML/WhatIsTML.md
-[SwitchTMLVersion]: https://github.com/lyc-Lacewing/tMLAllInOne/blob/master/IssuesAndSolutions/tML/HowToChangeTMLVersion.md
-[GetTMods]: https://github.com/lyc-Lacewing/tMLAllInOne/blob/master/IssuesAndSolutions/tML/InstallMods.md
-[ModTable]: https://github.com/lyc-Lacewing/tMLAllInOne/blob/master/ModTable.md
+[GetTerraria]: ./issue-and-solutions/tML/GetTerraria.md
+[WhatIsTML]: ./issue-and-solutions/tML/WhatIsTML.md
+[SwitchTMLVersion]: ./issue-and-solutions/tML/HowToChangeTMLVersion.md
+[GetTMods]: ./issue-and-solutions/tML/InstallMods.md
+[ModTable]: mod-table.md
 
 [WikiLocalizationGuide]: https://github.com/tModLoader/tModLoader/wiki/zh-Localization-%E6%9C%AC%E5%9C%B0%E5%8C%96
-[InternalLocalization]: https://github.com/lyc-Lacewing/tMLAllInOne/blob/master/Explained/LocalizationExplained/InternalLocalization.md
-[DotBuffList]: https://github.com/lyc-Lacewing/tMLAllInOne/blob/master/Explained/BuffExplained/DotBuffList.md
-[ImmunityFrames]: https://github.com/lyc-Lacewing/tMLAllInOne/blob/master/Explained/ImmunityFramesExplained/ImmunityFramesExplained.md
+[InternalLocalization]: ./explained/LocalizationExplained/InternalLocalization.md
+[DotBuffList]: ./explained/BuffExplained/DotBuffList.md
+[ImmunityFrames]: ./explained/ImmunityFramesExplained/ImmunityFramesExplained.md
 
-[ExternalLinks]: https://github.com/lyc-Lacewing/tMLAllInOne/blob/master/ExternalLinks.md
-[TerrariaTexture]: https://github.com/lyc-Lacewing/tMLAllInOne/tree/master/Resources/TerrariaImages
-[.NET6.0]: https://github.com/lyc-Lacewing/tMLAllInOne/tree/master/Resources/.NET6.0
+[ExternalLinks]: external-links.md
+[TerrariaTexture]: ./resources/TerrariaImages
+[.NET6.0]: ./resources/.NET6.0

--- a/explained/ImmunityFramesExplained/ImmunityFramesExplained.md
+++ b/explained/ImmunityFramesExplained/ImmunityFramesExplained.md
@@ -81,37 +81,37 @@ Debuff并不通过**攻击**来造成伤害, 而是通过将目标的生命回�
 ```cs
 	public void UpdateImmunity() 
 	{
-		if (immune) //要是无敌,就
+		if (immune) // 要是无敌,就
 		{
-			immuneTime--; //减少无敌时长
-			if (immuneTime <= 0) //无敌时长 <= 0 就不无敌了
+			immuneTime--; // 减少无敌时长
+			if (immuneTime <= 0) // 无敌时长 <= 0 就不无敌了
 			{
-				immune = false; //不无敌
-				immuneNoBlink = false; //重置这个bool, 不然下次也不闪
+				immune = false; // 不无敌
+				immuneNoBlink = false; // 重置这个bool, 不然下次也不闪
 			}
 
-			if (immuneNoBlink) //如果不闪烁
+			if (immuneNoBlink) // 如果不闪烁
 			{
-				immuneAlpha = 0; //透明度 = 0
+				immuneAlpha = 0; // 透明度 = 0
 			}
 			else 
 			{
-				immuneAlpha += immuneAlphaDirection * 50; //变化透明度
+				immuneAlpha += immuneAlphaDirection * 50; // 变化透明度
 				if (immuneAlpha <= 50)
-					immuneAlphaDirection = 1; //透明度加还是减, 1 是加 -1 是减
+					immuneAlphaDirection = 1; // 透明度加还是减, 1 是加 -1 是减
 				else if (immuneAlpha >= 205)
 					immuneAlphaDirection = -1;
 			}
 		}
 		else 
 		{
-			immuneAlpha = 0; //完全不透明, 正常显示
+			immuneAlpha = 0; // 完全不透明, 正常显示
 		}
 
 		for (int i = 0; i < hurtCooldowns.Length; i++) 
 		{
 			if (hurtCooldowns[i] > 0)
-				hurtCooldowns[i]--; //同时也减少对应 hurtCooldowns 的值
+				hurtCooldowns[i]--; // 同时也减少对应 hurtCooldowns 的值
 		}
 	}
 ```
@@ -119,13 +119,13 @@ Debuff并不通过**攻击**来造成伤害, 而是通过将目标的生命回�
 #### 设置全局无敌帧
 
 ```cs
-	public void SetImmuneTimeForAllTypes(int time) //这里传入要设置的无敌时间
+	public void SetImmuneTimeForAllTypes(int time) // 这里传入要设置的无敌时间
 	{
-		immune = true; //得无敌才有用
-		immuneTime = time; //无敌时间设为time
+		immune = true; // 得无敌才有用
+		immuneTime = time; // 无敌时间设为time
 		for (int i = 0; i < hurtCooldowns.Length; i++) 
 		{
-			hurtCooldowns[i] = time; //把所有的hurtCooldowns设为time
+			hurtCooldowns[i] = time; // 把所有的hurtCooldowns设为time
 		}
 	}
 ```
@@ -170,17 +170,17 @@ Debuff并不通过**攻击**来造成伤害, 而是通过将目标的生命回�
 
 ```cs
 	bool flag = !immune;
-	bool flag2 = false; //用于判断是否用特殊击退公式
+	bool flag2 = false; // 用于判断是否用特殊击退公式
 	switch (cooldownCounter) {
-		case 0: //物块的接触伤害, 在HurtTile里给伤害
-		case 1: //Boss单位
-		case 3: //抓岩浆生物
-		case 4: //岩浆伤害
-			flag = (hurtCooldowns[cooldownCounter] <= 0); //只有受击冷却<=0了才受伤
+		case 0: // 物块的接触伤害, 在HurtTile里给伤害
+		case 1: // Boss单位
+		case 3: // 抓岩浆生物
+		case 4: // 岩浆伤害
+			flag = (hurtCooldowns[cooldownCounter] <= 0); // 只有受击冷却<=0了才受伤
 			break;
-		case 2: //塔防兽人攻击
-			flag2 = true; //使用特殊的击退公式
-			cooldownCounter = -1; //其它还是用 -1 的
+		case 2: // 塔防兽人攻击
+			flag2 = true; // 使用特殊的击退公式
+			cooldownCounter = -1; // 其它还是用 -1 的
 			break;
 	}
 ```
@@ -188,28 +188,28 @@ Debuff并不通过**攻击**来造成伤害, 而是通过将目标的生命回�
 #### 给伤害和无敌帧
 
 ```cs
-	Color color = Crit ? CombatText.DamagedFriendlyCrit : CombatText.DamagedFriendly; //普通跟暴击有不同的颜色
-	CombatText.NewText(new Rectangle((int)position.X, (int)position.Y, width, height), color, (int)num2, Crit); //头上跳数字
-	statLife -= (int)num2; //扣血
-	switch (cooldownCounter) //判断要给予的无敌帧类型
+	Color color = Crit ? CombatText.DamagedFriendlyCrit : CombatText.DamagedFriendly; // 普通跟暴击有不同的颜色
+	CombatText.NewText(new Rectangle((int)position.X, (int)position.Y, width, height), color, (int)num2, Crit); // 头上跳数字
+	statLife -= (int)num2; // 扣血
+	switch (cooldownCounter) // 判断要给予的无敌帧类型
 	{
-		case -1: //普通无敌帧
+		case -1: // 普通无敌帧
 			{
-				immune = true; //得无敌才有用
-				int num14 = 0; //意义不明
-				//玩家打玩家(PvP)的话就只给8; 只有1点伤害就给20, 大于1点伤害就给40, 十字项链就翻倍
+				immune = true; // 得无敌才有用
+				int num14 = 0; // 意义不明
+				// 玩家打玩家(PvP)的话就只给8; 只有1点伤害就给20, 大于1点伤害就给40, 十字项链就翻倍
 				num14 = (immuneTime = (pvp ? 8 : ((num2 != 1.0) ? (longInvince ? 80 : 40) : (longInvince ? 40 : 20))));
 				break;
 			}
-		case 0: //物块伤害
-			if (num2 == 1.0) //如果是1伤害
-				hurtCooldowns[cooldownCounter] = (longInvince ? 40 : 20);//只给20
+		case 0: // 物块伤害
+			if (num2 == 1.0) // 如果是1伤害
+				hurtCooldowns[cooldownCounter] = (longInvince ? 40 : 20); // 只给20
 			else
-				hurtCooldowns[cooldownCounter] = (longInvince ? 80 : 40);//给40
+				hurtCooldowns[cooldownCounter] = (longInvince ? 80 : 40); // 给40
 			break;
 		case 1:
 		case 3:
-		case 4: //岩浆伤害
+		case 4: // 岩浆伤害
 			if (num2 == 1.0)
 				hurtCooldowns[cooldownCounter] = (longInvince ? 40 : 20);
 			else
@@ -221,13 +221,13 @@ Debuff并不通过**攻击**来造成伤害, 而是通过将目标的生命回�
 #### 塔防兽人的攻击
 
 ```cs
-	if (flag2 && hitDirection != 0) //如果是塔防兽人的攻击且要击退
+	if (flag2 && hitDirection != 0) // 如果是塔防兽人的攻击且要击退
 	{
-		if (!mount.Active || !mount.Cart) //不在坐骑上也不在矿车上
+		if (!mount.Active || !mount.Cart) // 不在坐骑上也不在矿车上
 		{
-			float num23 = 10.5f; //水平方向击飞的乘数
-			float y2 = -7.5f; //竖直方向的击飞
-			if (noKnockback) //如果"免疫击退"则受到更小的击退
+			float num23 = 10.5f; // 水平方向击飞的乘数
+			float y2 = -7.5f; // 竖直方向的击飞
+			if (noKnockback) // 如果"免疫击退"则受到更小的击退
 			{
 				num23 = 2.5f;
 				y2 = -1.5f;
@@ -244,7 +244,7 @@ Debuff并不通过**攻击**来造成伤害, 而是通过将目标的生命回�
 #### 如果`!immune`(不无敌)才继续进行受伤的步骤
 
 ```cs
-	if (flag) //bool flag = !immune, immune为false那flag就为true
+	if (flag) // bool flag = !immune, immune为false那flag就为true
 	{
 		if (whoAmI == Main.myPlayer && blackBelt && Main.rand.Next(10) == 0) 
 		{
@@ -279,11 +279,11 @@ Debuff并不通过**攻击**来造成伤害, 而是通过将目标的生命回�
 #### 物块的接触伤害
 
 ```cs
-	else if (vector3.Y != 0f) //这个 vector3 是 HurtTile 返回的一个 Vector2
+	else if (vector3.Y != 0f) // 这个 vector3 是 HurtTile 返回的一个 Vector2
 	{
 		int damage3 = Main.DamageVar(vector3.Y, 0f - luck);
 		Hurt(PlayerDeathReason.ByOther(3), damage3, 0, pvp: false, quiet: false, Crit: false, 0);
-		if (vector3.Y == 60f || vector3.Y == 80f) //原版不是这么搞的, tML才是 These values have to match TileID.Sets.TouchDamageOther, which is unused in vanilla and was not up to date with 1.4 --direwolf420
+		if (vector3.Y == 60f || vector3.Y == 80f) // 原版不是这么搞的, tML才是 These values have to match TileID.Sets.TouchDamageOther, which is unused in vanilla and was not up to date with 1.4 --direwolf420
 			AddBuff(30, Main.rand.Next(240, 600));
 	}
 ```

--- a/issue-and-solutions/tML/WhatIsTML.md
+++ b/issue-and-solutions/tML/WhatIsTML.md
@@ -19,5 +19,5 @@ tML，全称tModLoader，是泰拉瑞亚的模组加载器，实际上也是一�
 你需要选择测试版本或手动调整文件，详见[切换tML版本][HowToChangeTMLVersion]
 
 
-[GetTerraria]: https://github.com/lyc-Lacewing/tMLAllInOne/blob/master/IssuesAndSolutions/tML/GetTerraria.md
-[HowToChangeTMLVersion]: https://github.com/lyc-Lacewing/tMLAllInOne/blob/master/IssuesAndSolutions/tML/HowToChangeTMLVersion.md
+[GetTerraria]: ../tML/GetTerraria.md
+[HowToChangeTMLVersion]: ../tML/HowToChangeTMLVersion.md

--- a/mod-details/WeaponDisplay.md
+++ b/mod-details/WeaponDisplay.md
@@ -1,0 +1,1 @@
+# Weapon Display

--- a/mod-details/_ReplaceString_.md
+++ b/mod-details/_ReplaceString_.md
@@ -13,7 +13,7 @@ Repalce String (以下简称RS) 是一个用于其它模组的本地化的模组
 你也可以在[本仓库里][RSLocPacks]找到一些RS汉化包
 
 ## 使用方法
-[此文档](https://github.com/lyc-Lacewing/tMLAllInOne/blob/master/Explained/ReplaceStringExplained/replace_string_1.4.3.6_usage.md)讲解了RS的使用方法  
+[此文档](../explained/ReplaceStringExplained/replace_string_1.4.3.6_usage.md)讲解了RS的使用方法  
 [此视频][RSIntroVid]详细讲解了RS的使用方法
 
 

--- a/mod-table.md
+++ b/mod-table.md
@@ -138,18 +138,18 @@
 ****指需要自行获取源码并编译或通过特殊手段获得
 
 
-[AlchemistNPCLite]: https://github.com/lyc-Lacewing/tMLAllInOne/blob/master/ModDetails/AlchemistNPCLite.md
-[NoFishingQuests]: https://github.com/lyc-Lacewing/tMLAllInOne/blob/master/ModDetails/NoFishingQuests.md
-[WeaponDisplay]: https://github.com/lyc-Lacewing/tMLAllInOne/blob/master/ModDetails/WeaponDisplay.md
-[Autofish]: https://github.com/lyc-Lacewing/tMLAllInOne/blob/master/ModDetails/Autofish.md
-[BetterBossBar]: https://github.com/lyc-Lacewing/tMLAllInOne/blob/master/ModDetails/BetterBossBar.md
-[BloodSoul]: https://github.com/lyc-Lacewing/tMLAllInOne/blob/master/ModDetails/BloodSoul.md
-[BossChecklist]: https://github.com/lyc-Lacewing/tMLAllInOne/blob/master/ModDetails/BossChecklist.md
-[CalamityMod]: https://github.com/lyc-Lacewing/tMLAllInOne/blob/master/ModDetails/CalamityMod.md
-[CalamityAmmo]: https://github.com/lyc-Lacewing/tMLAllInOne/blob/master/ModDetails/CalamityAmmo.md
-[Catalyst]: https://github.com/lyc-Lacewing/tMLAllInOne/blob/master/ModDetails/Catalyst.md
-[CheapReforging]: https://github.com/lyc-Lacewing/tMLAllInOne/blob/master/ModDetails/CheapReforging.md
-[Consolaria]: https://github.com/lyc-Lacewing/tMLAllInOne/blob/master/ModDetails/Consolaria.md
-[I]: https://github.com/lyc-Lacewing/tMLAllInOne/blob/master/ModDetails/I.md
-[_ReplaceString_]: https://github.com/lyc-Lacewing/tMLAllInOne/blob/master/ModDetails/_ReplaceString_.md
-[Wild]: https://github.com/lyc-Lacewing/tMLAllInOne/blob/master/ModDetails/Wild.md
+[AlchemistNPCLite]: ./mod-details/AlchemistNPCLite.md
+[NoFishingQuests]: ./mod-details/NoFishingQuests.md
+[WeaponDisplay]: ./mod-details/WeaponDisplay.md
+[Autofish]: ./mod-details/Autofish.md
+[BetterBossBar]: ./mod-details/BetterBossBar.md
+[BloodSoul]: ./mod-details/BloodSoul.md
+[BossChecklist]: ./mod-details/BossChecklist.md
+[CalamityMod]: ./mod-details/CalamityMod.md
+[CalamityAmmo]: ./mod-details/CalamityAmmo.md
+[Catalyst]: ./mod-details/Catalyst.md
+[CheapReforging]: ./mod-details/CheapReforging.md
+[Consolaria]: ./mod-details/Consolaria.md
+[I]: ./mod-details/I.md
+[_ReplaceString_]: ./mod-details/_ReplaceString_.md
+[Wild]: ./mod-details/Wild.md


### PR DESCRIPTION
将所有（如果没漏掉哪个的话）导向仓库内部的链接改为路径，并修复了文件夹改名带来的找不到文件错误

为 ImmunityFramesExplained.md 文件内的所有双斜杠注释后加上空格，这样更美观